### PR TITLE
fix: guard against null default_roles in assignDefaultRoles

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,3 +82,22 @@ Please let us know if you need any commercial support. We dont have such a busin
 # Want to contribute?
 You are very welcome to contribute of course. Please send us an email so that we can get in touch and talk about details;
 support@plusclouds.com
+
+
+---
+
+## Our Libraries
+
+This library is part of the **NextDeveloper / PlusClouds open-source ecosystem**. Browse all available libraries and find the right building blocks for your next project:
+
+[https://plusclouds.com/us/solutions/libraries](https://plusclouds.com/us/solutions/libraries)
+
+---
+
+## Join the Community
+
+We believe great software is built together. The PlusClouds developer community is a place where engineers share ideas, ask questions, showcase what they have built, and help shape the direction of these libraries. Whether you are integrating a single package or building an entire platform on top of our stack, you are very welcome here.
+
+Come and join us — we would love to see what you build:
+
+[https://plusclouds.com/us/community](https://plusclouds.com/us/community)

--- a/readme.md
+++ b/readme.md
@@ -81,4 +81,4 @@ Please let us know if you need any commercial support. We dont have such a busin
 
 # Want to contribute?
 You are very welcome to contribute of course. Please send us an email so that we can get in touch and talk about details;
-codewithus@nextdeveloper.com
+support@plusclouds.com

--- a/src/Services/RolesService.php
+++ b/src/Services/RolesService.php
@@ -70,7 +70,13 @@ class RolesService extends AbstractRolesService
 
     public static function assignDefaultRoles(Users $user, Accounts $account)
     {
-        foreach (config('leo.register.default_roles') as $roleName) {
+        $defaultRoles = config('leo.register.default_roles');
+
+        if(!$defaultRoles) {
+            return;
+        }
+
+        foreach ($defaultRoles as $roleName) {
             $getRole = RolesService::getRoleByName($roleName);
 
             if(!$getRole) {


### PR DESCRIPTION
## Summary
- `assignDefaultRoles()` iterates over `config('leo.register.default_roles')` which can return `null` when the key is not configured, causing a fatal `foreach` error
- Added an early return when `$defaultRoles` is null/empty

## Test plan
- [ ] Call `assignDefaultRoles()` on an app where `leo.register.default_roles` is not set — verify no fatal error
- [ ] Call with `default_roles` configured — verify roles are still assigned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)