### PR TITLE
Fix getLeoOwnerAccount returning token owner account when account-sco…

### DIFF
--- a/src/Helpers/UserHelper.php
+++ b/src/Helpers/UserHelper.php
@@ -809,7 +809,20 @@ class UserHelper
 
     public static function getLeoOwnerAccount(): Accounts
     {
-        return self::currentAccount(self::getLeoOwner());
+        $leoOwner = self::getLeoOwner();
+
+        // currentAccount() returns the cached self::$account when set, ignoring the $user
+        // argument entirely. When an account-scoped token is active, that would return the
+        // token owner's account instead of the leo owner's account. Query directly to avoid
+        // the cache.
+        $relation = AccountUsers::withoutGlobalScope(AuthorizationScope::class)
+            ->where('iam_user_id', $leoOwner->id)
+            ->where('is_active', 1)
+            ->first();
+
+        return Accounts::withoutGlobalScope(AuthorizationScope::class)
+            ->where('id', $relation->iam_account_id)
+            ->first();
     }
 
     public static function runAsAdmin(callable $callback)


### PR DESCRIPTION
…ped token is active

currentAccount() short-circuits on the cached self::$account, ignoring the passed $user. getLeoOwnerAccount() now queries AccountUsers directly for the leo owner, bypassing the cache so runAsAdmin always switches to the correct admin account context.