### PR TITLE
fix: resolve UUID to integer id before raw iam_account_user insert

### DIFF
--- a/src/Services/AccountsService.php
+++ b/src/Services/AccountsService.php
@@ -166,8 +166,15 @@ class AccountsService extends AbstractAccountsService
 
         $account = parent::create($data);
 
+        $userId = $data['iam_user_id'];
+        if (\Illuminate\Support\Str::isUuid($userId)) {
+            $userId = Users::withoutGlobalScope(\NextDeveloper\IAM\Database\Scopes\AuthorizationScope::class)
+                ->where('uuid', $userId)
+                ->value('id');
+        }
+
         DB::table('iam_account_user')->insert([
-            'iam_user_id'       =>  $data['iam_user_id'],
+            'iam_user_id'       =>  $userId,
             'iam_account_id'    =>  $account->id,
             'is_active'         =>  false,
             'session_data'      =>  null


### PR DESCRIPTION
## Summary
- `AccountsService::create()` was inserting `$data['iam_user_id']` (a UUID string) directly into the `bigint` `iam_account_user.iam_user_id` column
- `parent::create()` converts UUID→int in its own copy of the array (PHP passes arrays by value), leaving the original variable as a UUID
- Added a guard: if `iam_user_id` is a UUID, resolve it to the integer `id` via a `Users` lookup before the raw `DB::table` insert

## Root cause
`PlusCloudsCrmPusher::createAccount()` passes `$owner->uuid` to `AccountsService::create()`, which then reaches the raw insert unchanged.

## Test plan
- [ ] Trigger `PlusCloudsCrmPusher` with a new lead that has no existing account — account creation should succeed without `SQLSTATE[22P02]`
- [ ] Verify `iam_account_user` row is created with the correct integer `iam_user_id`
- [ ] Existing callers that already pass an integer id are unaffected (guard only fires for UUID strings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)