### PR TITLE
fix: guard against null user in RolesService::getUserRoles

### DIFF
--- a/src/Services/RolesService.php
+++ b/src/Services/RolesService.php
@@ -113,6 +113,20 @@ class RolesService extends AbstractRolesService
         if(!$account)
             return null;
 
+        if(!$user) {
+            //  $user is null here (eg. queue jobs / NATS handlers with no authenticated request).
+            //  Log the current request() values so we can trace where this call originated from.
+            Log::error('[RolesService@getUserRoles] $user is null. Request values: ' . json_encode([
+                'url' => request()->fullUrl(),
+                'method' => request()->method(),
+                'headers' => request()->headers->all(),
+                'query' => request()->query(),
+                'body' => request()->all(),
+            ]));
+
+            return null;
+        }
+
         $roles = UserRoles::withoutGlobalScope(AuthorizationScope::class)
             // Here we have limits scope because if a user has more than 20 roles,
             // then some of them are not put into account


### PR DESCRIPTION
## Summary
- `RolesService::getUserRoles()` checked for a null `$account` but not a null `$user`, so calling it from contexts with no authenticated user (e.g. queue/NATS jobs) crashed with `Attempt to read property "id" on null`.
- Added the matching null `$user` guard, and log `request()` values (url, method, headers, query, body) when it's hit, to help trace which job/path is calling in with no user.

## Test plan
- [x] `php -l src/Services/RolesService.php`