### PR TITLE
feat: add withRolesCheckBypassed() to bypass role checks without switching identity

### DIFF
--- a/src/Helpers/UserHelper.php
+++ b/src/Helpers/UserHelper.php
@@ -586,6 +586,28 @@ class UserHelper
         return self::$isBypassRolesCheck;
     }
 
+    /**
+     * Runs $callback with role/policy checks bypassed, without switching the
+     * current user/account (unlike runAsAdmin()). For system-triggered side
+     * effects of an already-authorized action (e.g. writing an audit log entry
+     * as part of a user-permitted operation) where the acting identity must be
+     * preserved for correct attribution.
+     *
+     * Note: bypassRolesCheck(false) does NOT clear the flag (its truthy check
+     * only ever sets it to true), so the flag is saved/restored directly here.
+     */
+    public static function withRolesCheckBypassed(callable $callback)
+    {
+        $previousBypass = self::$isBypassRolesCheck;
+        self::$isBypassRolesCheck = true;
+
+        try {
+            return $callback();
+        } finally {
+            self::$isBypassRolesCheck = $previousBypass;
+        }
+    }
+
     public static function can($method, $model, Users $user = null)
     {
         if (self::bypassRolesCheck())


### PR DESCRIPTION
## Summary
- `bypassRolesCheck(false)` is a no-op — its truthy check (`$bypass && is_bool($bypass)`) only ever sets the flag to `true`, never resets it
- `runAsAdmin()` bypasses checks but also swaps the current user/account, which corrupts `iam_user_id`/`iam_account_id` attribution for anything created while bypassed
- Adds `withRolesCheckBypassed(callable $callback)`: save/restore the bypass flag around a callback without touching the current identity, for system-triggered side effects of an already-authorized action (e.g. `nextdeveloper-nl/s3`'s audit log writes, see companion PR)

## Test plan
- [ ] Unit: flag is restored to its previous value after the callback runs, including when the callback throws
- [ ] Companion `nextdeveloper-nl/s3` PR depends on this method