### PR TITLE
fix: TokenGuard should return null for non-uuid bearer tokens, not crash

### DIFF
--- a/src/Auth/Guards/TokenGuard.php
+++ b/src/Auth/Guards/TokenGuard.php
@@ -59,6 +59,12 @@ class TokenGuard implements Guard
         if($token == null)
             return null;
 
+        //  oauth_access_tokens.id is a uuid column - a non-uuid bearer token (e.g. a token
+        //  minted by another module for its own anonymous endpoints) would otherwise make
+        //  Postgres throw "invalid input syntax for type uuid" instead of just not matching.
+        if(!Str::isUuid($token))
+            return null;
+
         $oauthToken = DB::table('oauth_access_tokens')
             ->select('*')
             ->where('id', $token)


### PR DESCRIPTION
## Summary
- `TokenGuard::user()` queried `oauth_access_tokens` by `id = <bearer token>` without checking the token is uuid-shaped first. `oauth_access_tokens.id` is a `uuid` column, so a non-uuid bearer token made Postgres throw `invalid input syntax for type uuid` instead of the guard just returning "no user."
- Hit in practice via LLMOcean's new anonymous `agent-instances/authenticate` endpoint: it's rate-limited with Laravel's `ThrottleRequests`, which always calls `$request->user()` to choose a throttle key (falls back to IP only if no user resolves) — regardless of whether IAM auth is required for the route. The agent-instance bearer token (40-char random, not a uuid) crashed the guard before `ThrottleRequests` ever got to fall back to IP.
- Fix: `Str::isUuid($token)` guard before the query — returns `null` early, same as the existing "no token at all" branch. A non-uuid token could never match a real oauth token anyway, so this doesn't change behavior for any legitimate caller.

## Test plan
- [x] `php -l`
- [ ] Confirm `POST /llmocean/agent-instances/authenticate` with a valid agent-instance token (non-uuid) no longer 500s

🤖 Generated with [Claude Code](https://claude.com/claude-code)