### PR TITLE
fix: guard against getRoles() returning null in has() and getRoleForModel()

### DIFF
--- a/src/Helpers/UserHelper.php
+++ b/src/Helpers/UserHelper.php
@@ -544,6 +544,10 @@ class UserHelper
         //  If null getRoles will get the current user
         $roles = self::getRoles($user);
 
+        if (!$roles) {
+            return false;
+        }
+
         //  This works correct, if anything goes wrong, look at the database
         foreach ($roles as $role) {
             if ($role->name == $string)
@@ -556,6 +560,10 @@ class UserHelper
     public static function getRoleForModel($model, Users $user = null): ?Roles
     {
         $roles = self::getRoles($user);
+
+        if (!$roles) {
+            return null;
+        }
 
         foreach ($roles as $role) {
             if (!class_exists($role->class)) {


### PR DESCRIPTION
## Summary
- `UserHelper::getRoles()` is typed `?Collection` and returns null when `RolesService::getUserRoles()` finds nothing for the user/account pair.
- `has()` and `getRoleForModel()` both did `foreach ($roles as $role)` unconditionally, crashing with `foreach() argument must be of type array|object, null given` instead of handling the null case the return type already signals.
- Surfaced via `App\Jobs\IAAS\UpdateDatacenterResourcesJob` failing in production through `ActionsObserver->saving()` → `UserHelper::can()` → `bypassRolesCheck()` → `hasRole()` → `has()`.

## Test plan
- [ ] `php -l src/Helpers/UserHelper.php` passes (done locally)
- [ ] Confirm `has()`/`getRoleForModel()` return `false`/`null` gracefully when a user has no roles in the current account context